### PR TITLE
Component 0.14 and Node 0.10 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ module.exports = function(builder) {
     var loadPaths = (pkg.config.paths || []).map(pkg.path).concat(pkg.path('components'));
 
     // Get the real path for each file relative to the package
-    var realSassFiles = sassfiles.map(pkg.path);
+    // Must pass in package as context to make sure we have the correct context
+    var realSassFiles = sassfiles.map(pkg.path, pkg);
 
     // Function to compile sass files that will include the package
     // load paths as Sass load paths

--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
 var sass = require('node-sass');
 var path = require('path');
 var fs = require('fs');
-var async = require('async')
+var async = require('async');
 
 module.exports = function(builder) {
   builder.hook('before styles', function(pkg, next) {
 
     // No styles in this package
-    if(pkg.root !== true || !pkg.conf.styles) return next();
+    if(pkg.root !== true || !pkg.config.styles) return next();
 
     // Get all the coffee files from the scripts list
-    var sassfiles = pkg.conf.styles.filter(function(file){
+    var sassfiles = pkg.config.styles.filter(function(file){
       return path.extname(file) === '.scss';
     });
 
@@ -18,7 +18,7 @@ module.exports = function(builder) {
     if( sassfiles.length === 0 ) return next();
 
     // Sass load paths
-    var loadPaths = (pkg.conf.paths || []).map(pkg.path).concat(pkg.path('components'));
+    var loadPaths = (pkg.config.paths || []).map(pkg.path).concat(pkg.path('components'));
 
     // Get the real path for each file relative to the package
     var realSassFiles = sassfiles.map(pkg.path);
@@ -45,7 +45,7 @@ module.exports = function(builder) {
           pkg.addFile('styles', sassfiles[i], data);
           pkg.removeFile('styles', sassfiles[i]);
         });
-       
+
         next();
       });
     });


### PR DESCRIPTION
As of component 0.14.0, the builder has renamed the `conf` property to `config`. There has also been a change as of Node 0.10 that makes path.join throw a TypeError `Arguments to path.join must be strings`. 

This pull request makes sure it works on component 0.14 and also makes sure the realSassFiles doesn't throw an error on node 0.10. 
